### PR TITLE
Fix unconditional scaffold cancel + barrier/structure-void box fixes

### DIFF
--- a/src/main/java/amymialee/peculiarpieces/VisibleBarriersAccess.java
+++ b/src/main/java/amymialee/peculiarpieces/VisibleBarriersAccess.java
@@ -9,11 +9,11 @@ public class VisibleBarriersAccess {
     public static BooleanSupplier visibility = () -> false;
 
     public static boolean areStructureVoidsEnabled() {
-        return structureVoids.getAsBoolean();
+        return isVisibilityEnabled() || structureVoids.getAsBoolean();
     }
 
     public static boolean areBarriersEnabled() {
-        return barriers.getAsBoolean();
+        return isVisibilityEnabled() || barriers.getAsBoolean();
     }
 
     public static boolean isVisibilityEnabled() {

--- a/src/main/java/amymialee/peculiarpieces/blocks/EntityBarrierBlock.java
+++ b/src/main/java/amymialee/peculiarpieces/blocks/EntityBarrierBlock.java
@@ -22,6 +22,12 @@ public class EntityBarrierBlock extends Block {
     }
 
     @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        if (context.isHolding(this.asItem()) || VisibleBarriersAccess.areBarriersEnabled()) return VoxelShapes.fullCube();
+        return VoxelShapes.empty();
+    }
+
+    @Override
     public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
         if (context instanceof EntityShapeContext entityShapeContext && entityShapeContext.getEntity() instanceof PlayerEntity) {
             return getShape(false);

--- a/src/main/java/amymialee/peculiarpieces/mixin/EntityAccessor.java
+++ b/src/main/java/amymialee/peculiarpieces/mixin/EntityAccessor.java
@@ -1,5 +1,6 @@
 package amymialee.peculiarpieces.mixin;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -8,4 +9,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 public interface EntityAccessor {
     @Accessor
     void setTouchingWater(boolean value);
+    @Accessor
+    void setBlockStateAtPos(BlockState state);
 }


### PR DESCRIPTION
This causes Peculiar Pieces to break mods like Better Climbing. This is a really hairy bit of code, Mojang sure does love to hardcode stuff.

Also now fixes the issues with barriers/etc noticed on the BC23 server.

<details markdown>
<summary>Legal stuff you don't care about</summary>



Copyright (C) 2023 Una Thompson

Permission is hereby granted, free of charge, to Amy Mialee, the sole recipient of this patch against the software source code of the Peculiar Pieces Minecraft mod (the "Patch"), to deal in the Patch without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Patch, and to permit persons to whom the Patch is furnished to do so. No conditions are imposed. This permission may not be revoked.

**The Patch is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Patch or the use or other dealings in the Patch.**

</details>