### PR TITLE
Apply Jump Pad to Entities

### DIFF
--- a/src/main/java/amymialee/peculiarpieces/util/JumpPaddableEntity.java
+++ b/src/main/java/amymialee/peculiarpieces/util/JumpPaddableEntity.java
@@ -1,0 +1,8 @@
+package amymialee.peculiarpieces.util;
+
+public interface JumpPaddableEntity {
+
+    boolean canJumpOnPad();
+
+    void setJumpOnPad(boolean jumpOnPad);
+}


### PR DESCRIPTION
Closes #32 

Allows entities to 'jump' on the pads. As entities don't typically jump on their own, the logic applied allows entities to jump on the pad if they pass over it. To prevent some weird double jump cases, the entities are only bounced once before being put in a deadzone they must move out of to jump on the pads again.