### PR TITLE
Fix #39 and lay groundwork for synced gamerules + grammar fix.

### DIFF
--- a/src/main/java/amymialee/peculiarpieces/PeculiarPiecesClient.java
+++ b/src/main/java/amymialee/peculiarpieces/PeculiarPiecesClient.java
@@ -19,6 +19,7 @@ import amymialee.peculiarpieces.particles.WardingParticle;
 import amymialee.peculiarpieces.registry.PeculiarBlocks;
 import amymialee.peculiarpieces.registry.PeculiarEntities;
 import amymialee.peculiarpieces.registry.PeculiarItems;
+import amymialee.peculiarpieces.registry.PeculiarPackets;
 import amymialee.peculiarpieces.screens.CouriporterScreen;
 import amymialee.peculiarpieces.screens.CreativeBarrelScreen;
 import amymialee.peculiarpieces.screens.EquipmentStandScreen;
@@ -68,8 +69,11 @@ public class PeculiarPiecesClient implements ClientModInitializer {
     public static final EntityModelLayer EQUIPMENT_STAND = new EntityModelLayer(PeculiarPieces.id("equipment_stand"), "main");
     private final FlagBlockEntity renderFlag = new FlagBlockEntity(BlockPos.ORIGIN, PeculiarBlocks.FLAG.getDefaultState());
 
+    public static boolean StrongerLeadsClientRule = false;
+
     @Override
     public void onInitializeClient() {
+        PeculiarPackets.registerS2CPackets();
         BlockRenderLayerMap.INSTANCE.putBlock(PeculiarBlocks.CHECKPOINT, RenderLayer.getTranslucent());
         BlockRenderLayerMap.INSTANCE.putBlock(PeculiarBlocks.CHECKPOINT_REMOVER, RenderLayer.getTranslucent());
         BlockRenderLayerMap.INSTANCE.putBlock(PeculiarBlocks.CHECKPOINT_RETURNER, RenderLayer.getTranslucent());

--- a/src/main/java/amymialee/peculiarpieces/mixin/GameRuleRuleMixin.java
+++ b/src/main/java/amymialee/peculiarpieces/mixin/GameRuleRuleMixin.java
@@ -1,0 +1,23 @@
+package amymialee.peculiarpieces.mixin;
+
+import amymialee.peculiarpieces.PeculiarPieces;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.world.GameRules.Rule;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Rule.class)
+public class GameRuleRuleMixin {
+    @Inject(
+            method = "Lnet/minecraft/world/GameRules$Rule;set(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)V",
+            at = @At("TAIL")
+    )
+    public void set(CommandContext<ServerCommandSource> context, String name, CallbackInfo ci) {
+        MinecraftServer server = context.getSource().getServer();
+        server.getPlayerManager().getPlayerList().forEach(PeculiarPieces::syncGameRuleToClient);
+    }
+}

--- a/src/main/java/amymialee/peculiarpieces/mixin/MobEntityMixin.java
+++ b/src/main/java/amymialee/peculiarpieces/mixin/MobEntityMixin.java
@@ -1,9 +1,12 @@
 package amymialee.peculiarpieces.mixin;
 
+import amymialee.peculiarpieces.PeculiarPieces;
+import amymialee.peculiarpieces.PeculiarPiecesClient;
 import amymialee.peculiarpieces.registry.PeculiarItems;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.Monster;
 import net.minecraft.entity.mob.SlimeEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -14,6 +17,8 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.world.GameRules;
+import net.minecraft.server.MinecraftServer;
 
 @SuppressWarnings("ConstantConditions")
 @Mixin(MobEntity.class)
@@ -24,10 +29,16 @@ public abstract class MobEntityMixin extends LivingEntity {
 
     @Shadow public abstract boolean isLeashed();
 
+    @Shadow protected abstract void updateLeash();
+
+    @Shadow public abstract void detachLeash(boolean sendPacket, boolean dropItem);
+
     @Inject(method = "canBeLeashedBy", at = @At("HEAD"), cancellable = true)
     public void PeculiarPieces$CreativeLeashes(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
         if (!this.isLeashed()) {
-            cir.setReturnValue(true);
+            boolean isNormallyLeashable = !this.isLeashed() && !(this instanceof Monster);
+            boolean re = isNormallyLeashable || (this.getWorld().isClient() ? PeculiarPiecesClient.StrongerLeadsClientRule : getWorld().getGameRules().get(PeculiarPieces.StrongerLeadsGamerule).get());
+            cir.setReturnValue(re);
         }
     }
 

--- a/src/main/java/amymialee/peculiarpieces/registry/PeculiarPackets.java
+++ b/src/main/java/amymialee/peculiarpieces/registry/PeculiarPackets.java
@@ -1,0 +1,40 @@
+package amymialee.peculiarpieces.registry;
+
+import amymialee.peculiarpieces.PeculiarPieces;
+import amymialee.peculiarpieces.PeculiarPiecesClient;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public class PeculiarPackets {
+    public static final Identifier SYNC_STRONGER_LEADS_PACKET_ID = new Identifier(PeculiarPieces.MOD_ID, "sync_stronger_leads");
+
+    public static void registerPackets() {
+
+        ServerPlayNetworking.registerGlobalReceiver(SYNC_STRONGER_LEADS_PACKET_ID, (server, player, handler, buf, responseSender) -> {
+            boolean strongerLeadsRule = buf.readBoolean();
+                server.execute(() -> {
+            });
+        });
+    }
+
+    public static void registerS2CPackets() {
+
+        ClientPlayNetworking.registerGlobalReceiver(PeculiarPackets.SYNC_STRONGER_LEADS_PACKET_ID, (client, handler, buf, responseSender) -> {
+            boolean strongerLeadsRule = buf.readBoolean();
+            client.execute(() -> {
+                PeculiarPiecesClient.StrongerLeadsClientRule = strongerLeadsRule;
+            });
+        });
+    }
+
+    public static void sendGameRuleToClient(ServerPlayerEntity player, boolean gameRuleValue) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeBoolean(gameRuleValue);
+        ServerPlayNetworking.send(player, SYNC_STRONGER_LEADS_PACKET_ID, buf);
+    }
+}

--- a/src/main/resources/assets/peculiarpieces/lang/en_us.json
+++ b/src/main/resources/assets/peculiarpieces/lang/en_us.json
@@ -311,7 +311,7 @@
   "peculiarpieces.pearl.empty" : "Empty.",
   "peculiarpieces.transport_pearl.empty" : "%s: Empty.",
   "peculiarpieces.pearl.bind" : "Shift click to bind to a location.",
-  "peculiarpieces.pearl.bind_stone" : "Shift click on a lodestone to bind to it's location.",
+  "peculiarpieces.pearl.bind_stone" : "Shift click on a lodestone to bind to its location.",
   "peculiarpieces.checkpoint_cleared" : "Checkpoint Cleared",
   "peculiarpieces.checkpoint_returned" : "Returned To Checkpoint",
   "peculiarpieces.spawnpoint_returned" : "Returned To Spawnpoint"

--- a/src/main/resources/peculiarpieces.mixins.json
+++ b/src/main/resources/peculiarpieces.mixins.json
@@ -22,6 +22,7 @@
     "EntityMixin",
     "ExplosionMixin",
     "FluidBlockMixin",
+    "GameRuleRuleMixin",
     "HopperBlockEntityMixin",
     "ItemEntityMixin",
     "ItemStackMixin",
@@ -33,11 +34,11 @@
     "PistonBlockMixin",
     "PlayerEntityMixin",
     "PowderSnowBlockMixin",
+    "RedstoneViewMixin",
     "RedstoneWireBlockMixin",
     "SculkShriekerBlockMixin",
     "SheepEntityMixin",
-    "StatusEffectInstanceAccessor",
-    "RedstoneViewMixin"
+    "StatusEffectInstanceAccessor"
   ],
   "client": [
     "CapeFeatureRendererMixin",


### PR DESCRIPTION
This PR:

- Fixes a grammar issue in `peculiarpieces.pearl.bind_stone` in en_us.json
- Adds a gamerule as suggested in #39 to make stronger leads option. It is by default true.
    - This also adds a custom packet to sync the gamerule to the client, so there's no weirdness regarding clientside leading.

